### PR TITLE
Extend cluster role to create namespaces and delete priorityclasses

### DIFF
--- a/hack/test-deployment/connectivity-proxy-operator-all.yaml
+++ b/hack/test-deployment/connectivity-proxy-operator-all.yaml
@@ -489,61 +489,6 @@ spec:
       subresources:
         status: {}
 ---
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: "connectivity-proxy-operator"
-  namespace: kyma-system
-spec:
-  selector:
-    matchLabels:
-      app: "connectivity-proxy-operator"
-  template:
-    metadata:
-      labels:
-        app: "connectivity-proxy-operator"
-    spec:
-      serviceAccountName: "connectivity-proxy-operator"
-      imagePullSecrets:
-        - name: "commons-artifactory-pull-secret"
-      initContainers:
-        - name: init-migrator
-          image: europe-docker.pkg.dev/kyma-project/prod/cp-mod-migrator:latest
-          imagePullPolicy: Always
-          securityContext:
-            runAsUser: 1337
-        - name: init-backup
-          image: europe-docker.pkg.dev/kyma-project/prod/cp-mod-backup:latest
-          imagePullPolicy: Always
-          securityContext:
-            runAsUser: 1337
-        - name: init-cleaner
-          image: europe-docker.pkg.dev/kyma-project/prod/cp-mod-cleaner:latest
-          imagePullPolicy: Always
-          securityContext:
-            runAsUser: 1337
-      containers:
-        - name: "connectivity-proxy-operator"
-          image: "connectivity.common.repositories.cloud.sap/chuchulski/test-proxy-operator:test"
-          imagePullPolicy: "Always"
-          env:
-            - name: START_APPLICATION
-              value: "proxy-operator"
-          resources:
-            requests:
-              cpu: "100m"
-              memory: "256M"
-            limits:
-              cpu: "1"
-              memory: "1024M"
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: 8080
-              scheme: HTTP
-            initialDelaySeconds: 30
-            timeoutSeconds: 3
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -621,3 +566,58 @@ roleRef:
   kind: ClusterRole
   name: "connectivity-proxy-operator-rbac"
   apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "connectivity-proxy-operator"
+  namespace: kyma-system
+spec:
+  selector:
+    matchLabels:
+      app: "connectivity-proxy-operator"
+  template:
+    metadata:
+      labels:
+        app: "connectivity-proxy-operator"
+    spec:
+      serviceAccountName: "connectivity-proxy-operator"
+      imagePullSecrets:
+        - name: "commons-artifactory-pull-secret"
+      initContainers:
+        - name: init-migrator
+          image: europe-docker.pkg.dev/kyma-project/prod/cp-mod-migrator:latest
+          imagePullPolicy: Always
+          securityContext:
+            runAsUser: 1337
+        - name: init-backup
+          image: europe-docker.pkg.dev/kyma-project/prod/cp-mod-backup:latest
+          imagePullPolicy: Always
+          securityContext:
+            runAsUser: 1337
+        - name: init-cleaner
+          image: europe-docker.pkg.dev/kyma-project/prod/cp-mod-cleaner:latest
+          imagePullPolicy: Always
+          securityContext:
+            runAsUser: 1337
+      containers:
+        - name: "connectivity-proxy-operator"
+          image: "connectivity.common.repositories.cloud.sap/chuchulski/test-proxy-operator:test"
+          imagePullPolicy: "Always"
+          env:
+            - name: START_APPLICATION
+              value: "proxy-operator"
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "256M"
+            limits:
+              cpu: "1"
+              memory: "1024M"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 30
+            timeoutSeconds: 3

--- a/hack/test-deployment/connectivity-proxy-operator-all.yaml
+++ b/hack/test-deployment/connectivity-proxy-operator-all.yaml
@@ -574,6 +574,14 @@ rules:
   - apiGroups: [""]
     resources: ["serviceaccounts"]
     verbs: ["*"]
+  # Namespaces
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["*"]
+  # Priorityclasses
+  - apiGroups: ["scheduling.k8s.io"]
+    resources: ["priorityclasses"]
+    verbs: ["*"]
   # RBAC resources
   - apiGroups: ["rbac.authorization.k8s.io"]
     resources: ["roles", "clusterroles", "rolebindings", "clusterrolebindings"]

--- a/hack/test-deployment/connectivity-proxy-operator-all.yaml
+++ b/hack/test-deployment/connectivity-proxy-operator-all.yaml
@@ -522,7 +522,7 @@ rules:
   # Namespaces
   - apiGroups: [""]
     resources: ["namespaces"]
-    verbs: ["*"]
+    verbs: ["create, list", "get"]
   # Priorityclasses
   - apiGroups: ["scheduling.k8s.io"]
     resources: ["priorityclasses"]

--- a/hack/testdata/cp_default_mini_cr.yaml
+++ b/hack/testdata/cp_default_mini_cr.yaml
@@ -1,0 +1,20 @@
+apiVersion: "connectivityproxy.sap.com/v1"
+kind: ConnectivityProxy
+metadata:
+  name: connectivity-proxy
+  namespace: kyma-system
+spec:
+  config:
+    servers:
+      businessDataTunnel:
+        externalHost: "auto-provision"
+    subaccountId: "auto-provision"
+    subaccountSubdomain: "auto-provision"
+  ingress:
+    tls:
+      secretName: "auto-provision"
+  secretConfig:
+    integration:
+      connectivityService:
+        secretName: "auto-provision"
+---

--- a/images/cleaner/cleaner.sh
+++ b/images/cleaner/cleaner.sh
@@ -97,10 +97,11 @@ kubectl delete destinationrule -n kyma-system connectivity-proxy-tunnel-0 --igno
 kubectl delete destinationrule -n kyma-system connectivity-proxy --ignore-not-found
 kubectl delete peerauthentication -n kyma-system enable-permissive-mode-for-cp --ignore-not-found
 kubectl delete certificate -n istio-system cc-certs --ignore-not-found
-kubectl delete secret -n istio-system cc-certs-cacert --ignore-not-found
+
 
 echo "Removing Secrets"
-
+kubectl delete secret -n istio-system cc-certs-cacert --ignore-not-found
+kubectl delete secret -n istio-system cc-certs --ignore-not-found
 kubectl delete secret -n kyma-system connectivity-proxy-service-key --ignore-not-found
 kubectl delete secret -n kyma-system connectivity-sm-operator-secrets-tls --ignore-not-found
 

--- a/images/cleaner/cleaner.sh
+++ b/images/cleaner/cleaner.sh
@@ -101,7 +101,7 @@ kubectl delete secret -n istio-system cc-certs-cacert --ignore-not-found
 
 echo "Removing Secrets"
 
-# kubectl delete secret -n kyma-system connectivity-proxy-service-key --ignore-not-found
+kubectl delete secret -n kyma-system connectivity-proxy-service-key --ignore-not-found
 kubectl delete secret -n kyma-system connectivity-sm-operator-secrets-tls --ignore-not-found
 
 echo "Removing PriorityClass resources"


### PR DESCRIPTION
- Extend cluster role to create and read namespaces and delete priorityclasses
- Change order of object to create deployment as the last one 
- Remove connectivity-proxy-service-key secret from kyma-system namespace in cleaner script
- Remove cc-certs secret istio-system namespace  in cleaner script