### PR TITLE
Fix small problem - typo for RBAC yaml file

### DIFF
--- a/hack/test-deployment/connectivity-proxy-operator-all.yaml
+++ b/hack/test-deployment/connectivity-proxy-operator-all.yaml
@@ -522,7 +522,7 @@ rules:
   # Namespaces
   - apiGroups: [""]
     resources: ["namespaces"]
-    verbs: ["create, list", "get"]
+    verbs: ["create", "list", "get"]
   # Priorityclasses
   - apiGroups: ["scheduling.k8s.io"]
     resources: ["priorityclasses"]


### PR DESCRIPTION
Change 

    verbs: ["create, list", "get"]

into 

`    verbs: ["create", "list", "get"]`