### PR TITLE
Add labeling of migrated resources with app.kubernetes.io/managed-by=sap.connectivity.proxy.operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ It performs the following steps:
 2. Finds the default ConnectivityProxy CR
 3. Exits with success if the ConnectivityProxy CR doesn't exist
 4. Exits with success if the ConnectivityProxy CR has the `migrator.kyma-project.io/cleaned="true` annotation (cleanup was completed already)
-5. Migrates preexisting custom resources of type `servicemappings.connectivityproxy.sap.com` CRs and CRDs by adding:
+5. Migrates preexisting instances and definition of custom resources of type `servicemappings.connectivityproxy.sap.com` by adding:
    - Annotations `io.javaoperatorsdk/primary-name=connectivity-proxy` and `io.javaoperatorsdk/primary-namespace=kyma-system`
    - Label `app.kubernetes.io/managed-by=sap.connectivity.proxy.operator`
 6. Removes the legacy Connectivity Proxy 2.9.3 Kubernetes objects from the cluster (Deployments, StatefulSets, Services, ConfigMaps, etc.)

--- a/README.md
+++ b/README.md
@@ -54,8 +54,11 @@ It performs the following steps:
 2. Finds the default ConnectivityProxy CR
 3. Exits with success if the ConnectivityProxy CR doesn't exist
 4. Exits with success if the ConnectivityProxy CR has the `migrator.kyma-project.io/cleaned="true` annotation (cleanup was completed already)
-5. Removes the legacy Connectivity Proxy 2.9.3 Kubernetes objects from the cluster (Deployments, StatefulSets, Services, ConfigMaps, etc.)
-6. Adds the `migrator.kyma-project.io/cleaned="true"` annotation to the CR.
+5. Migrates preexisting custom resources of type `servicemappings.connectivityproxy.sap.com` CRs and CRDs by adding:
+   - Annotations `io.javaoperatorsdk/primary-name=connectivity-proxy` and `io.javaoperatorsdk/primary-namespace=kyma-system`
+   - Label `app.kubernetes.io/managed-by=sap.connectivity.proxy.operator`
+6. Removes the legacy Connectivity Proxy 2.9.3 Kubernetes objects from the cluster (Deployments, StatefulSets, Services, ConfigMaps, etc.)
+7. Adds the `migrator.kyma-project.io/cleaned="true"` annotation to the CR.
 
 
 ## Migration process

--- a/images/cleaner/cleaner.sh
+++ b/images/cleaner/cleaner.sh
@@ -38,19 +38,23 @@ if kubectl get crd servicemappings.connectivityproxy.sap.com &> /dev/null; then
 
   for mapping in $mappings; do
 
-    echo "Applying annotations to service mapping $mapping"
+    echo "Applying annotations and lables to service mapping $mapping"
 
     kubectl annotate servicemappings.connectivityproxy.sap.com "$mapping" \
       io.javaoperatorsdk/primary-name=connectivity-proxy \
       io.javaoperatorsdk/primary-namespace=kyma-system
 
+    kubectl label servicemappings.connectivityproxy.sap.com "$mapping" app.kubernetes.io/managed-by=sap.connectivity.proxy.operator
+
   done
 
-  echo "Applying annotations to service mapping CRD"
+  echo "Applying annotations and labels to service mapping CRD"
 
   kubectl annotate crd servicemappings.connectivityproxy.sap.com \
      io.javaoperatorsdk/primary-name=connectivity-proxy \
      io.javaoperatorsdk/primary-namespace=kyma-system
+
+  kubectl label crd servicemappings.connectivityproxy.sap.com app.kubernetes.io/managed-by=sap.connectivity.proxy.operator
 
 fi
 

--- a/images/cleaner/cleaner.sh
+++ b/images/cleaner/cleaner.sh
@@ -38,7 +38,7 @@ if kubectl get crd servicemappings.connectivityproxy.sap.com &> /dev/null; then
 
   for mapping in $mappings; do
 
-    echo "Applying annotations and lables to service mapping $mapping"
+    echo "Applying annotations and label to service mapping $mapping"
 
     kubectl annotate servicemappings.connectivityproxy.sap.com "$mapping" \
       io.javaoperatorsdk/primary-name=connectivity-proxy \
@@ -48,7 +48,7 @@ if kubectl get crd servicemappings.connectivityproxy.sap.com &> /dev/null; then
 
   done
 
-  echo "Applying annotations and labels to service mapping CRD"
+  echo "Applying annotations and label to service mapping CRD"
 
   kubectl annotate crd servicemappings.connectivityproxy.sap.com \
      io.javaoperatorsdk/primary-name=connectivity-proxy \


### PR DESCRIPTION
As requested instances and definition of custom resources of type `servicemappings.connectivityproxy.sap.com` will be additinaly  labeled with
` app.kubernetes.io/managed-by=sap.connectivity.proxy.operator`